### PR TITLE
Grid list selection drift

### DIFF
--- a/src/screens/Shell/ImageGridPanel/ImageCard.tsx
+++ b/src/screens/Shell/ImageGridPanel/ImageCard.tsx
@@ -1,4 +1,4 @@
-import { Skeleton, Tooltip } from '@heroui/react';
+import { Skeleton } from '@heroui/react';
 import { genThumbnail, type ImageInfo } from '@platform/file-manager';
 import { revealInDirLabel } from '@platform/menus/file-menu';
 import { Menu } from '@tauri-apps/api/menu';
@@ -30,43 +30,34 @@ function ImageCard({ path, filename }: ImageInfo) {
   });
 
   return (
-    <Tooltip delay={0}>
-      <Tooltip.Trigger>
-        <figure
-          className="flex justify-center items-center h-56 w-56"
-          onContextMenu={(e) => {
-            e.preventDefault();
-            showContextMenu(path).catch((err) => {
-              console.error('Failed to open image card context menu:', err);
-            });
-          }}
-        >
-          {error ? (
-            <HiOutlineExclamationTriangle size={40} />
-          ) : isLoading ? (
-            <Skeleton className="h-56 w-56 rounded-field" />
-          ) : (
-            <img
-              src={data}
-              alt={`${filename} thumbnail`}
-              className="h-56 object-cover rounded-field"
-              height={224}
-              width={224}
-            />
-          )}
-          <figcaption className="sr-only">{filename}</figcaption>
-        </figure>
-      </Tooltip.Trigger>
-
-      <Tooltip.Content
-        placement="bottom"
-        showArrow
-        className="bg-accent text-accent-foreground"
-      >
-        <Tooltip.Arrow className="[&>svg]:fill-accent" />
+    <figure
+      className="flex flex-col items-center gap-1 w-56"
+      onContextMenu={(e) => {
+        e.preventDefault();
+        showContextMenu(path).catch((err) => {
+          console.error('Failed to open image card context menu:', err);
+        });
+      }}
+    >
+      <div className="flex justify-center items-center h-56 w-56 group-data-selected:scale-93 motion-safe:transition-transform">
+        {error ? (
+          <HiOutlineExclamationTriangle size={40} />
+        ) : isLoading ? (
+          <Skeleton className="h-56 w-56 rounded-field" />
+        ) : (
+          <img
+            src={data}
+            alt={`${filename} thumbnail`}
+            className="h-56 object-cover rounded-field"
+            height={224}
+            width={224}
+          />
+        )}
+      </div>
+      <figcaption className="text-xs text-muted w-56 truncate text-center">
         {filename}
-      </Tooltip.Content>
-    </Tooltip>
+      </figcaption>
+    </figure>
   );
 }
 

--- a/src/screens/Shell/ImageGridPanel/ImageGridPanel.tsx
+++ b/src/screens/Shell/ImageGridPanel/ImageGridPanel.tsx
@@ -78,12 +78,7 @@ function ImageGridPanel({ onImageSelection }: Props) {
                 )
               }
             </ListBox.ItemIndicator>
-            <div
-              className="group-data-selected:scale-93 motion-safe:transition-transform"
-              key={image.path}
-            >
-              <ImageCard path={image.path} filename={image.filename} />
-            </div>
+            <ImageCard path={image.path} filename={image.filename} />
           </ListBox.Item>
         )}
       </ListBox>

--- a/src/screens/Shell/ImageGridPanel/__specs__/ImageGridPanel.spec.tsx
+++ b/src/screens/Shell/ImageGridPanel/__specs__/ImageGridPanel.spec.tsx
@@ -85,5 +85,36 @@ describe('ImageGridPanel', () => {
         },
       ]);
     });
+
+    it('anchors keyboard navigation to the most recently clicked image', async () => {
+      render(<ImageGridPanel onImageSelection={vi.fn()} />);
+
+      await act(async () => {
+        await emit(IMAGES_OPENED_EVENT, {
+          images: [
+            { filename: 'image1.jpg', path: '/image1.jpg' },
+            { filename: 'image2.jpg', path: '/image2.jpg' },
+            { filename: 'image3.jpg', path: '/image3.jpg' },
+            { filename: 'image4.jpg', path: '/image4.jpg' },
+            { filename: 'image5.jpg', path: '/image5.jpg' },
+          ],
+        });
+      });
+
+      await userEvent.click(await screen.findByAltText('image1.jpg thumbnail'));
+      await userEvent.keyboard('{ArrowDown}');
+      expect(screen.getByLabelText('image2.jpg')).toHaveAttribute(
+        'aria-selected',
+        'true',
+      );
+
+      await userEvent.click(screen.getByAltText('image4.jpg thumbnail'));
+      await userEvent.keyboard('{ArrowDown}');
+
+      expect(screen.getByLabelText('image5.jpg')).toHaveAttribute(
+        'aria-selected',
+        'true',
+      );
+    });
   });
 });

--- a/src/screens/Shell/ImageGridPanel/__specs__/ImageGridPanel.spec.tsx
+++ b/src/screens/Shell/ImageGridPanel/__specs__/ImageGridPanel.spec.tsx
@@ -52,6 +52,14 @@ describe('ImageGridPanel', () => {
 
       expect(await screen.findByAltText('image1.jpg thumbnail')).toBeVisible();
       expect(screen.getByAltText('image2.jpg thumbnail')).toBeVisible();
+
+      const imageOneCaption = screen.getByText('image1.jpg');
+      expect(imageOneCaption).toBeVisible();
+      expect(imageOneCaption).not.toHaveClass('sr-only');
+
+      const imageTwoCaption = screen.getByText('image2.jpg');
+      expect(imageTwoCaption).toBeVisible();
+      expect(imageTwoCaption).not.toHaveClass('sr-only');
     });
 
     it('can select an image', async () => {


### PR DESCRIPTION
The tooltip was intercepting the click event on the images, causing selecting the images with the arrow keys to originate from an image that wasn't what was selected if it was last selected by clicking.

Resolved by just getting rid of the tooltip.