### PR TITLE
Make Details Able To Be Seen Via UI

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { ToastProvider } from '@heroui/react';
 import { forwardLogging } from '@platform/logging';
 import { createAppMenu } from '@platform/menus/app-menu';
 import AboutModal from '@screens/AboutModal/AboutModal';
+import ErrorDetailModal from '@screens/ErrorDetailModal';
 import SettingsModal from '@screens/SettingsModal/SettingsModal';
 import Shell from '@screens/Shell/Shell';
 import { StrictMode } from 'react';
@@ -19,6 +20,7 @@ createRoot(root).render(
     <Shell />
     <AboutModal />
     <SettingsModal />
+    <ErrorDetailModal />
   </StrictMode>,
 );
 

--- a/src/platform/__specs__/error-reporter.spec.ts
+++ b/src/platform/__specs__/error-reporter.spec.ts
@@ -1,0 +1,77 @@
+import {
+  ERROR_REPORTED_EVENT,
+  type ErrorReport,
+  reportError,
+} from '@platform/error-reporter';
+import { listen } from '@tauri-apps/api/event';
+import { mockIPC } from '@tauri-apps/api/mocks';
+import { waitFor } from '@testing-library/react';
+
+describe('reportError', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIPC(() => {}, { shouldMockEvents: true });
+    vi.stubGlobal('console', { error: vi.fn() });
+  });
+
+  async function captureNextReport(): Promise<ErrorReport> {
+    return new Promise<ErrorReport>((resolve) => {
+      void listen<ErrorReport>(ERROR_REPORTED_EVENT, (event) => {
+        resolve(event.payload);
+      });
+    });
+  }
+
+  it('emits the event with the Error message as detail', async () => {
+    const reportPromise = captureNextReport();
+    reportError('Something failed', new Error('boom'));
+    await expect(reportPromise).resolves.toEqual({
+      message: 'Something failed',
+      detail: 'boom',
+    });
+  });
+
+  it('uses a string error directly as detail', async () => {
+    const reportPromise = captureNextReport();
+    reportError('Something failed', 'raw stderr text');
+    await expect(reportPromise).resolves.toEqual({
+      message: 'Something failed',
+      detail: 'raw stderr text',
+    });
+  });
+
+  it('emits empty detail for null', async () => {
+    const reportPromise = captureNextReport();
+    reportError('Something failed', null);
+    await expect(reportPromise).resolves.toEqual({
+      message: 'Something failed',
+      detail: '',
+    });
+  });
+
+  it('emits empty detail for undefined', async () => {
+    const reportPromise = captureNextReport();
+    reportError('Something failed', undefined);
+    await expect(reportPromise).resolves.toEqual({
+      message: 'Something failed',
+      detail: '',
+    });
+  });
+
+  it('falls back to String() for non-Error, non-string values', async () => {
+    const reportPromise = captureNextReport();
+    reportError('Something failed', { weird: true });
+    await expect(reportPromise).resolves.toEqual({
+      message: 'Something failed',
+      detail: '[object Object]',
+    });
+  });
+
+  it('logs the error via console.error', async () => {
+    const err = new Error('boom');
+    reportError('Something failed', err);
+    await waitFor(() =>
+      expect(console.error).toHaveBeenCalledWith('Something failed:', err),
+    );
+  });
+});

--- a/src/platform/__specs__/file-manager.spec.ts
+++ b/src/platform/__specs__/file-manager.spec.ts
@@ -1,4 +1,4 @@
-import { toast } from '@heroui/react';
+import { ERROR_REPORTED_EVENT } from '@platform/error-reporter';
 import { findImages, IMAGES_OPENED_EVENT } from '@platform/file-manager';
 import { listen } from '@tauri-apps/api/event';
 import { mockIPC } from '@tauri-apps/api/mocks';
@@ -9,15 +9,9 @@ import type { Mock } from 'vitest';
 
 vi.mock('@tauri-apps/plugin-dialog');
 vi.mock('@tauri-apps/api/path');
-vi.mock(import('@heroui/react'), async (importOriginal) => {
-  const original = await importOriginal();
-  original.toast.danger = vi.fn();
-  return original;
-});
 
 const openMock = open as unknown as Mock<typeof open>;
 const basenameMock = basename as unknown as Mock<typeof basename>;
-const toastMock = toast as unknown as Mock<typeof toast>;
 
 describe('findImages', () => {
   beforeEach(() => {
@@ -47,23 +41,31 @@ describe('findImages', () => {
   it('does nothing when the dialog returns no paths', async () => {
     openMock.mockResolvedValueOnce(null);
 
-    const handler = vi.fn();
-    await listen(IMAGES_OPENED_EVENT, handler);
+    const imagesHandler = vi.fn();
+    const errorHandler = vi.fn();
+    await listen(IMAGES_OPENED_EVENT, imagesHandler);
+    await listen(ERROR_REPORTED_EVENT, errorHandler);
 
     await findImages();
 
-    expect(handler).not.toHaveBeenCalled();
-    expect(toastMock.danger).not.toHaveBeenCalled();
+    expect(imagesHandler).not.toHaveBeenCalled();
+    expect(errorHandler).not.toHaveBeenCalled();
   });
 
-  it('toasts when the dialog fails', async () => {
+  it('reports an error when the dialog fails', async () => {
     vi.stubGlobal('console', { error: () => {} });
     openMock.mockRejectedValueOnce(new Error('boom'));
 
+    const handler = vi.fn();
+    await listen(ERROR_REPORTED_EVENT, (event) => handler(event.payload));
+
     await findImages();
 
-    expect(toastMock.danger).toHaveBeenCalledExactlyOnceWith(
-      'Failed adding images',
+    await waitFor(() =>
+      expect(handler).toHaveBeenCalledExactlyOnceWith({
+        message: 'Failed adding images',
+        detail: 'boom',
+      }),
     );
   });
 });

--- a/src/platform/error-reporter.ts
+++ b/src/platform/error-reporter.ts
@@ -1,0 +1,25 @@
+import { emit } from '@tauri-apps/api/event';
+
+export const ERROR_REPORTED_EVENT = 'error:reported';
+
+export interface ErrorReport {
+  message: string;
+  detail: string;
+}
+
+function normalizeDetail(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  if (error == null) return '';
+  return String(error);
+}
+
+export function reportError(message: string, error: unknown): void {
+  console.error(`${message}:`, error);
+  emit(ERROR_REPORTED_EVENT, {
+    message,
+    detail: normalizeDetail(error),
+  } satisfies ErrorReport).catch((err) => {
+    console.error('Failed to emit error report:', err);
+  });
+}

--- a/src/platform/file-manager.ts
+++ b/src/platform/file-manager.ts
@@ -1,8 +1,8 @@
-import { toast } from '@heroui/react';
 import { invoke } from '@tauri-apps/api/core';
 import { emit } from '@tauri-apps/api/event';
 import { basename } from '@tauri-apps/api/path';
 import { open } from '@tauri-apps/plugin-dialog';
+import { reportError } from './error-reporter';
 
 export interface ImageInfo {
   filename: string;
@@ -32,8 +32,7 @@ export async function findImages() {
 
     await imagesOpened(images);
   } catch (err) {
-    console.error('Failed adding images:', err);
-    toast.danger('Failed adding images');
+    reportError('Failed adding images', err);
   }
 }
 

--- a/src/screens/ErrorDetailModal.tsx
+++ b/src/screens/ErrorDetailModal.tsx
@@ -1,0 +1,52 @@
+import { Modal, toast } from '@heroui/react';
+import useTauriListener from '@hooks/useTauriListener';
+import {
+  ERROR_REPORTED_EVENT,
+  type ErrorReport,
+} from '@platform/error-reporter';
+import { useCallback, useState } from 'react';
+
+function ErrorDetailModal() {
+  const [detail, setDetail] = useState<string | null>(null);
+
+  const onReport = useCallback((report: ErrorReport) => {
+    if (report.detail) {
+      toast.danger(report.message, {
+        actionProps: {
+          variant: 'ghost',
+          children: 'Details',
+          onPress: () => setDetail(report.detail),
+        },
+      });
+    } else {
+      toast.danger(report.message);
+    }
+  }, []);
+
+  useTauriListener<ErrorReport>(ERROR_REPORTED_EVENT, onReport);
+
+  return (
+    <Modal.Backdrop
+      isOpen={detail !== null}
+      onOpenChange={(open) => {
+        if (!open) setDetail(null);
+      }}
+    >
+      <Modal.Container scroll="inside" size="lg">
+        <Modal.Dialog>
+          <Modal.CloseTrigger />
+          <Modal.Header>
+            <Modal.Heading>Error Details</Modal.Heading>
+          </Modal.Header>
+          <Modal.Body>
+            <pre className="whitespace-pre-wrap break-words text-sm">
+              {detail}
+            </pre>
+          </Modal.Body>
+        </Modal.Dialog>
+      </Modal.Container>
+    </Modal.Backdrop>
+  );
+}
+
+export default ErrorDetailModal;

--- a/src/screens/SettingsModal/SettingsForm.tsx
+++ b/src/screens/SettingsModal/SettingsForm.tsx
@@ -9,6 +9,7 @@ import {
   toast,
 } from '@heroui/react';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { reportError } from '@platform/error-reporter';
 import { loadSettings, Settings, saveSettings } from '@platform/settings';
 import { Controller, useForm } from 'react-hook-form';
 import useSWR from 'swr';
@@ -36,8 +37,7 @@ function SettingsForm({ onClose }: Props) {
   const res = useSWR('settings', loadSettings, {
     revalidateOnFocus: false,
     onError(err) {
-      console.error('Failed to load settings:', err);
-      toast.danger('Failed to load settings');
+      reportError('Failed to load settings', err);
     },
   });
 
@@ -68,8 +68,7 @@ function SettingsForm({ onClose }: Props) {
               toast.success('Settings Saved', { timeout: 3_000 });
               onClose();
             } catch (err) {
-              console.error('Failed to save settings:', err);
-              toast.danger('Failed to save settings');
+              reportError('Failed to save settings', err);
             }
           })}
         >

--- a/src/screens/SettingsModal/__specs__/SettingsModal.spec.tsx
+++ b/src/screens/SettingsModal/__specs__/SettingsModal.spec.tsx
@@ -1,7 +1,8 @@
 import { toast } from '@heroui/react';
+import { ERROR_REPORTED_EVENT } from '@platform/error-reporter';
 import { OPEN_SETTINGS_EVENT } from '@platform/menus/app-menu';
 import { loadSettings, type Settings, saveSettings } from '@platform/settings';
-import { emit } from '@tauri-apps/api/event';
+import { emit, listen } from '@tauri-apps/api/event';
 import { mockIPC } from '@tauri-apps/api/mocks';
 import {
   act,
@@ -39,7 +40,6 @@ vi.mock(import('@platform/settings'), async (importOriginal) => {
 
 vi.mock(import('@heroui/react'), async (importOriginal) => {
   const original = await importOriginal();
-  original.toast.danger = vi.fn();
   original.toast.success = vi.fn();
   return original;
 });
@@ -58,6 +58,9 @@ describe('SettingsModal', () => {
   });
 
   it('has a form for settings', async () => {
+    const errorHandler = vi.fn();
+    await listen(ERROR_REPORTED_EVENT, (event) => errorHandler(event.payload));
+
     render(<SettingsModal />);
     await act(async () => {
       await emit(OPEN_SETTINGS_EVENT);
@@ -84,13 +87,16 @@ describe('SettingsModal', () => {
         timeout: 3_000,
       },
     );
-    expect(toastMock.danger).not.toHaveBeenCalled();
+    expect(errorHandler).not.toHaveBeenCalled();
   });
 
-  it('shows an alert if the settings fail to load', async () => {
+  it('reports an error if the settings fail to load', async () => {
     vi.stubGlobal('console', { error: () => {} });
     mockLoadSettings.mockReset();
-    mockLoadSettings.mockRejectedValue(new Error('boom'));
+    mockLoadSettings.mockRejectedValue(new Error('load boom'));
+
+    const errorHandler = vi.fn();
+    await listen(ERROR_REPORTED_EVENT, (event) => errorHandler(event.payload));
 
     render(<SettingsModal />);
     await act(async () => {
@@ -98,13 +104,19 @@ describe('SettingsModal', () => {
     });
 
     await waitFor(() =>
-      expect(toastMock.danger).toHaveBeenCalledWith('Failed to load settings'),
+      expect(errorHandler).toHaveBeenCalledWith({
+        message: 'Failed to load settings',
+        detail: 'load boom',
+      }),
     );
   });
 
-  it('shows an alert if the settings fail to save', async () => {
+  it('reports an error if the settings fail to save', async () => {
     vi.stubGlobal('console', { error: () => {} });
-    mockSaveSettings.mockRejectedValueOnce(new Error('boom'));
+    mockSaveSettings.mockRejectedValueOnce(new Error('save boom'));
+
+    const errorHandler = vi.fn();
+    await listen(ERROR_REPORTED_EVENT, (event) => errorHandler(event.payload));
 
     render(<SettingsModal />);
     await act(async () => {
@@ -118,9 +130,10 @@ describe('SettingsModal', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() =>
-      expect(toastMock.danger).toHaveBeenCalledExactlyOnceWith(
-        'Failed to save settings',
-      ),
+      expect(errorHandler).toHaveBeenCalledExactlyOnceWith({
+        message: 'Failed to save settings',
+        detail: 'save boom',
+      }),
     );
     expect(screen.getByText('Settings')).toBeVisible();
   });

--- a/src/screens/Shell/MetadataEditorPanel/MetadataEditorPanel.tsx
+++ b/src/screens/Shell/MetadataEditorPanel/MetadataEditorPanel.tsx
@@ -32,7 +32,7 @@ function MetadataEditorPanel({ selectedImages }: Props) {
   const exifDataRes = useSWR(selectedImages, readMetadata, {
     revalidateOnFocus: false,
     onError(err) {
-      console.error('Failed reading metadata for selection:', err);
+      reportError('Failed to read metadata', err);
     },
   });
 

--- a/src/screens/Shell/MetadataEditorPanel/MetadataEditorPanel.tsx
+++ b/src/screens/Shell/MetadataEditorPanel/MetadataEditorPanel.tsx
@@ -5,6 +5,7 @@ import useTauriListener from '@hooks/useTauriListener';
 import { defaultExifData, ExifData } from '@metadata-handler/exifdata';
 import { readMetadata } from '@metadata-handler/read';
 import { updateMetadata } from '@metadata-handler/update';
+import { reportError } from '@platform/error-reporter';
 import type { ImageInfo } from '@platform/file-manager';
 import EditMenu from '@platform/menus/edit-menu';
 import FileMenu, { SAVE_METADATA_EVENT } from '@platform/menus/file-menu';
@@ -122,9 +123,7 @@ function MetadataEditorPanel({ selectedImages }: Props) {
     try {
       await updateMetadata(selectedImages, newExif);
     } catch (err) {
-      console.error('Failed saving:', newExif);
-      console.error(err);
-      toast.danger('Failed to save images');
+      reportError('Failed to save images', err);
       return;
     }
 

--- a/src/screens/Shell/MetadataEditorPanel/__specs__/MetadataEditorPanel.spec.tsx
+++ b/src/screens/Shell/MetadataEditorPanel/__specs__/MetadataEditorPanel.spec.tsx
@@ -89,12 +89,25 @@ describe('MetadataEditorPanel', () => {
 
       it('indicates failure with no form even with partial load error', async () => {
         readMetadataMock.mockRejectedValueOnce(new Error('No'));
+
+        const errorHandler = vi.fn();
+        await listen(ERROR_REPORTED_EVENT, (event) =>
+          errorHandler(event.payload),
+        );
+
         render(<MetadataEditorPanel selectedImages={selectedImages} />);
         await waitForElementToBeRemoved(
           screen.queryByText('Loading Metadata...'),
         );
         expect(screen.getByText('Error Loading Metadata')).toBeVisible();
         expect(screen.queryByText('No Image Selected')).toBeNull();
+
+        await waitFor(() =>
+          expect(errorHandler).toHaveBeenCalledExactlyOnceWith({
+            message: 'Failed to read metadata',
+            detail: 'No',
+          }),
+        );
       });
     });
 

--- a/src/screens/Shell/MetadataEditorPanel/__specs__/MetadataEditorPanel.spec.tsx
+++ b/src/screens/Shell/MetadataEditorPanel/__specs__/MetadataEditorPanel.spec.tsx
@@ -1,7 +1,9 @@
 import { toast } from '@heroui/react';
 import { readMetadata } from '@metadata-handler/read';
 import { updateMetadata } from '@metadata-handler/update';
+import { ERROR_REPORTED_EVENT } from '@platform/error-reporter';
 import type { ImageInfo } from '@platform/file-manager';
+import { listen } from '@tauri-apps/api/event';
 import { mockIPC } from '@tauri-apps/api/mocks';
 import type { load } from '@tauri-apps/plugin-store';
 import {
@@ -35,7 +37,6 @@ vi.mock('@metadata-handler/read');
 vi.mock('@metadata-handler/update');
 vi.mock(import('@heroui/react'), async (importOriginal) => {
   const original = await importOriginal();
-  original.toast.danger = vi.fn();
   original.toast.success = vi.fn();
   return original;
 });
@@ -174,7 +175,6 @@ describe('MetadataEditorPanel', () => {
           expect(artistInput).toBeEnabled();
 
           await userEvent.type(artistInput, 'T');
-          expect(toastMock.danger).not.toHaveBeenCalled();
           const saveButton = screen.getByRole('button', { name: 'Save' });
           expect(saveButton).toBeEnabled();
           await userEvent.click(saveButton);
@@ -260,8 +260,13 @@ describe('MetadataEditorPanel', () => {
             vi.stubGlobal('console', { error: () => {} });
           });
 
-          it('indicates when an image fails to save', async () => {
+          it('reports the error and re-enables the form', async () => {
             updateMetadataMock.mockRejectedValueOnce(new Error('No'));
+
+            const errorHandler = vi.fn();
+            await listen(ERROR_REPORTED_EVENT, (event) =>
+              errorHandler(event.payload),
+            );
 
             await userEvent.click(screen.getByRole('button', { name: 'Edit' }));
 
@@ -269,8 +274,11 @@ describe('MetadataEditorPanel', () => {
             await userEvent.type(artistInput, 'T');
             await userEvent.click(screen.getByRole('button', { name: 'Save' }));
 
-            expect(toastMock.danger).toHaveBeenCalledWith(
-              'Failed to save images',
+            await waitFor(() =>
+              expect(errorHandler).toHaveBeenCalledExactlyOnceWith({
+                message: 'Failed to save images',
+                detail: 'No',
+              }),
             );
             expect(artistInput).toBeEnabled();
           });

--- a/src/screens/Shell/__specs__/Shell.spec.tsx
+++ b/src/screens/Shell/__specs__/Shell.spec.tsx
@@ -21,7 +21,6 @@ vi.mock('@tauri-apps/plugin-store', () => ({
 }));
 vi.mock(import('@heroui/react'), async (importOriginal) => {
   const original = await importOriginal();
-  original.toast.danger = vi.fn();
   original.toast.success = vi.fn();
   return original;
 });

--- a/src/screens/__specs__/ErrorDetailModal.spec.tsx
+++ b/src/screens/__specs__/ErrorDetailModal.spec.tsx
@@ -1,0 +1,111 @@
+import { ToastProvider, toast } from '@heroui/react';
+import {
+  ERROR_REPORTED_EVENT,
+  type ErrorReport,
+} from '@platform/error-reporter';
+import { emit } from '@tauri-apps/api/event';
+import { mockIPC } from '@tauri-apps/api/mocks';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ErrorDetailModal from '../ErrorDetailModal';
+
+function renderModal() {
+  render(
+    <>
+      <ToastProvider />
+      <ErrorDetailModal />
+    </>,
+  );
+}
+
+async function emitReport(report: ErrorReport) {
+  await act(async () => {
+    await emit(ERROR_REPORTED_EVENT, report);
+  });
+}
+
+describe('ErrorDetailModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIPC(() => {}, { shouldMockEvents: true });
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      toast.clear();
+    });
+  });
+
+  it('shows a danger toast with a Details button when detail is non-empty', async () => {
+    renderModal();
+    await emitReport({
+      message: 'Failed adding images',
+      detail: 'exiftool says no',
+    });
+
+    expect(await screen.findByText('Failed adding images')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Details' })).toBeVisible();
+  });
+
+  it('opens a modal with the detail when Details is clicked', async () => {
+    renderModal();
+    await emitReport({
+      message: 'Failed adding images',
+      detail: 'exiftool says no',
+    });
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Details' }),
+    );
+
+    expect(screen.getByText('Error Details')).toBeVisible();
+    expect(screen.getByText('exiftool says no')).toBeVisible();
+  });
+
+  it('renders no Details button when detail is empty', async () => {
+    renderModal();
+    await emitReport({
+      message: 'Failed adding images',
+      detail: '',
+    });
+
+    expect(await screen.findByText('Failed adding images')).toBeVisible();
+    expect(screen.queryByRole('button', { name: 'Details' })).toBeNull();
+  });
+
+  it('closes the modal via the close trigger', async () => {
+    renderModal();
+    await emitReport({
+      message: 'Failed adding images',
+      detail: 'exiftool says no',
+    });
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Details' }),
+    );
+    expect(screen.getByText('Error Details')).toBeVisible();
+
+    await userEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', { name: 'Close' }),
+    );
+
+    await waitFor(() => expect(screen.queryByText('Error Details')).toBeNull());
+  });
+
+  it('preserves each toast detail in its own closure when multiple errors arrive', async () => {
+    renderModal();
+    await emitReport({ message: 'First error', detail: 'first detail' });
+    await emitReport({ message: 'Second error', detail: 'second detail' });
+
+    const detailsButtons = await screen.findAllByRole('button', {
+      name: 'Details',
+    });
+    expect(detailsButtons.length).toBeGreaterThanOrEqual(2);
+
+    // The most recently rendered toast appears first in the queue.
+    // Click the older toast's Details button (last in the array).
+    await userEvent.click(detailsButtons[detailsButtons.length - 1]);
+
+    expect(screen.getByText('first detail')).toBeVisible();
+  });
+});


### PR DESCRIPTION
If exiftool failed, I wanted to be able to see exactly why without looking at the console, which is helpful for if it's just a data issue.