### PR TITLE
Vanilla MapLibre in LocationMap

### DIFF
--- a/__mocks__/react-map-gl/maplibre.tsx
+++ b/__mocks__/react-map-gl/maplibre.tsx
@@ -1,2 +1,0 @@
-export default () => <div>MapGL Output</div>;
-export const Marker = () => <div>Marker</div>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.58.1",
         "react-icons": "^5.5.0",
-        "react-map-gl": "^8.0.4",
         "react-resizable-panels": "^4.7.1",
         "swr": "^2.3.6",
         "tailwindcss": "^4.1.12",
@@ -3217,66 +3216,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@vis.gl/react-mapbox": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@vis.gl/react-mapbox/-/react-mapbox-8.1.0.tgz",
-      "integrity": "sha512-FwvH822oxEjWYOr+pP2L8hpv+7cZB2UsQbHHHT0ryrkvvqzmTgt7qHDhamv0EobKw86e1I+B4ojENdJ5G5BkyQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mapbox-gl": ">=3.5.0",
-        "react": ">=16.3.0",
-        "react-dom": ">=16.3.0"
-      },
-      "peerDependenciesMeta": {
-        "mapbox-gl": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vis.gl/react-maplibre": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@vis.gl/react-maplibre/-/react-maplibre-8.1.0.tgz",
-      "integrity": "sha512-PkAK/gp3mUfhCLhUuc+4gc3PN9zCtVGxTF2hB6R5R5yYUw+hdg84OZ770U5MU4tPMTCG6fbduExuIW6RRKN6qQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@maplibre/maplibre-gl-style-spec": "^19.2.1"
-      },
-      "peerDependencies": {
-        "maplibre-gl": ">=4.0.0",
-        "react": ">=16.3.0",
-        "react-dom": ">=16.3.0"
-      },
-      "peerDependenciesMeta": {
-        "maplibre-gl": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vis.gl/react-maplibre/node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "19.3.3",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.3.tgz",
-      "integrity": "sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==",
-      "license": "ISC",
-      "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/unitbezier": "^0.0.1",
-        "json-stringify-pretty-compact": "^3.0.0",
-        "minimist": "^1.2.8",
-        "rw": "^1.3.3",
-        "sort-object": "^3.0.3"
-      },
-      "bin": {
-        "gl-style-format": "dist/gl-style-format.mjs",
-        "gl-style-migrate": "dist/gl-style-migrate.mjs",
-        "gl-style-validate": "dist/gl-style-validate.mjs"
-      }
-    },
-    "node_modules/@vis.gl/react-maplibre/node_modules/json-stringify-pretty-compact": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
-      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
-      "license": "MIT"
-    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.4.tgz",
@@ -3488,15 +3427,6 @@
         "dequal": "^2.0.3"
       }
     },
-    "node_modules/arr-union": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3505,15 +3435,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/assign-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -3578,25 +3499,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/bytewise": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
-      "integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bytewise-core": "^1.2.2",
-        "typewise": "^1.0.3"
-      }
-    },
-    "node_modules/bytewise-core": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
-      "integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
-      "license": "MIT",
-      "dependencies": {
-        "typewise-core": "^1.2"
       }
     },
     "node_modules/caniuse-lite": {
@@ -3925,18 +3827,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -4005,15 +3895,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-value": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/gl-matrix": {
@@ -4109,27 +3990,6 @@
         "tslib": "^2.8.0"
       }
     },
-    "node_modules/is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -4143,15 +4003,6 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -4956,30 +4807,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/react-map-gl": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-8.1.0.tgz",
-      "integrity": "sha512-vDx/QXR3Tb+8/ap/z6gdMjJQ8ZEyaZf6+uMSPz7jhWF5VZeIsKsGfPvwHVPPwGF43Ryn+YR4bd09uEFNR5OPdg==",
-      "license": "MIT",
-      "dependencies": {
-        "@vis.gl/react-mapbox": "8.1.0",
-        "@vis.gl/react-maplibre": "8.1.0"
-      },
-      "peerDependencies": {
-        "mapbox-gl": ">=1.13.0",
-        "maplibre-gl": ">=1.13.0",
-        "react": ">=16.3.0",
-        "react-dom": ">=16.3.0"
-      },
-      "peerDependenciesMeta": {
-        "mapbox-gl": {
-          "optional": true
-        },
-        "maplibre-gl": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -5166,21 +4993,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/set-value": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
-      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -5188,84 +5000,12 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/sort-asc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.2.0.tgz",
-      "integrity": "sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sort-desc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.2.0.tgz",
-      "integrity": "sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sort-object": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-3.0.3.tgz",
-      "integrity": "sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bytewise": "^1.1.0",
-        "get-value": "^2.0.2",
-        "is-extendable": "^0.1.1",
-        "sort-asc": "^0.2.0",
-        "sort-desc": "^0.2.0",
-        "union-value": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/split-string": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/split-string/node_modules/extend-shallow": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/split-string/node_modules/is-extendable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5537,21 +5277,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/typewise": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
-      "integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "typewise-core": "^1.2.0"
-      }
-    },
-    "node_modules/typewise-core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-      "integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
-      "license": "MIT"
-    },
     "node_modules/undici": {
       "version": "7.22.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
@@ -5568,21 +5293,6 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/union-value": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
-      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
-      "license": "MIT",
-      "dependencies": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.58.1",
     "react-icons": "^5.5.0",
-    "react-map-gl": "^8.0.4",
     "react-resizable-panels": "^4.7.1",
     "swr": "^2.3.6",
     "tailwindcss": "^4.1.12",

--- a/src/platform/error-reporter.ts
+++ b/src/platform/error-reporter.ts
@@ -14,8 +14,17 @@ function normalizeDetail(error: unknown): string {
   return String(error);
 }
 
-export function reportError(message: string, error: unknown): void {
+export function reportError(
+  message: string,
+  error: unknown,
+  logOnly?: boolean,
+): void {
   console.error(`${message}:`, error);
+
+  if (logOnly) {
+    return;
+  }
+
   emit(ERROR_REPORTED_EVENT, {
     message,
     detail: normalizeDetail(error),

--- a/src/screens/Shell/MetadataEditorPanel/LocationMap.tsx
+++ b/src/screens/Shell/MetadataEditorPanel/LocationMap.tsx
@@ -1,12 +1,14 @@
+import { Skeleton } from '@heroui/react';
 import useTauriListener from '@hooks/useTauriListener';
 import type { ExifData } from '@metadata-handler/exifdata';
 import { FOCUS_ON_LOCATION_EVENT } from '@platform/menus/tools-menu';
 import { load } from '@tauri-apps/plugin-store';
-import type { MapLibreEvent } from 'maplibre-gl';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import maplibregl, { type Map as MaplibreMap } from 'maplibre-gl';
+import { useEffect, useRef, useState } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { useFormContext } from 'react-hook-form';
 import { MdLocationPin } from 'react-icons/md';
-import MapGL, { type MapRef, Marker } from 'react-map-gl/maplibre';
+import useSWR from 'swr';
 import { z } from 'zod';
 
 const Loc = z.object({
@@ -17,32 +19,70 @@ const Loc = z.object({
 
 type Loc = z.infer<typeof Loc>;
 
-function LocationPin() {
+const DEFAULT_LOC: Loc = { lat: 0, lng: 0, zoom: 0 } as const;
+const MAP_STYLE = 'https://tiles.openfreemap.org/styles/bright';
+const INITIAL_LOC_KEY = 'initialLoc';
+const SWR_KEY = 'locationMap.initialLoc';
+
+async function loadInitialLoc(): Promise<Loc> {
+  try {
+    const store = await load('state.json');
+    const raw = await store.get(INITIAL_LOC_KEY);
+    const parsed = await Loc.safeParseAsync(raw);
+    return parsed.success ? parsed.data : DEFAULT_LOC;
+  } catch (err) {
+    console.error('Failed to load map state:', err);
+    return DEFAULT_LOC;
+  }
+}
+
+function LocationPin({ map }: { map: MaplibreMap }) {
   const { watch, getFieldState } = useFormContext<ExifData>();
   const lat = watch('GPSLatitude');
   const lon = watch('GPSLongitude');
+  const latInvalid = getFieldState('GPSLatitude').invalid;
+  const lonInvalid = getFieldState('GPSLongitude').invalid;
+  const markerRef = useRef<maplibregl.Marker | null>(null);
 
-  if (
-    getFieldState('GPSLatitude').invalid ||
-    getFieldState('GPSLongitude').invalid
-  ) {
-    return;
-  }
+  useEffect(() => {
+    const element = document.createElement('div');
+    element.innerHTML = renderToStaticMarkup(
+      <MdLocationPin color="red" size={36} />,
+    );
+    const marker = new maplibregl.Marker({ element });
+    markerRef.current = marker;
+    return () => {
+      marker.remove();
+      markerRef.current = null;
+    };
+  }, []);
 
-  if (lat === undefined || lat === null || lon === undefined || lon === null) {
-    return;
-  }
+  useEffect(() => {
+    const marker = markerRef.current;
+    if (!marker) {
+      return;
+    }
 
-  return (
-    <Marker latitude={lat} longitude={lon} anchor="bottom">
-      <MdLocationPin color="red" size={36} />
-    </Marker>
-  );
+    const hasCoords =
+      typeof lat === 'number' &&
+      typeof lon === 'number' &&
+      Number.isFinite(lat) &&
+      Number.isFinite(lon);
+
+    if (hasCoords && !latInvalid && !lonInvalid) {
+      marker.setLngLat([lon, lat]).addTo(map);
+    } else {
+      marker.remove();
+    }
+  }, [lat, lon, latInvalid, lonInvalid, map]);
+
+  return null;
 }
 
-function LocationMap() {
-  const mapRef = useRef<MapRef>(null);
-  const [initialLoc, setInitialLoc] = useState<Loc | undefined>();
+function MapView({ initialLoc }: { initialLoc: Loc }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const initialLocRef = useRef(initialLoc);
+  const [map, setMap] = useState<MaplibreMap | null>(null);
   const {
     setValue,
     getValues,
@@ -50,74 +90,98 @@ function LocationMap() {
   } = useFormContext<ExifData>();
 
   useEffect(() => {
-    load('state.json')
-      .then((store) => store.get('initialLoc'))
-      .then((raw) => Loc.safeParseAsync(raw))
-      .then((savedInitialLoc) => {
-        const DEFAULT_LOC: Loc = { lat: 0, lng: 0, zoom: 0 } as const;
-        setInitialLoc(savedInitialLoc.data ?? DEFAULT_LOC);
-      })
-      .catch((err) => {
-        console.error('Failed to load map state:', err);
-      });
-  }, []);
-
-  useTauriListener(FOCUS_ON_LOCATION_EVENT, () => {
-    if (!mapRef.current) {
+    if (!containerRef.current) {
       return;
     }
+    const instance = new maplibregl.Map({
+      container: containerRef.current,
+      style: MAP_STYLE,
+      center: [initialLocRef.current.lng, initialLocRef.current.lat],
+      zoom: initialLocRef.current.zoom,
+    });
+    setMap(instance);
+    return () => {
+      instance.remove();
+      setMap(null);
+    };
+  }, []);
 
+  useEffect(() => {
+    if (!map) {
+      return;
+    }
+    const onClick = (e: { lngLat: { lat: number; lng: number } }) => {
+      if (disabled) {
+        return;
+      }
+      setValue('GPSLatitude', e.lngLat.lat, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+      setValue('GPSLongitude', e.lngLat.lng, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+    };
+    map.on('click', onClick);
+    return () => {
+      map.off('click', onClick);
+    };
+  }, [map, disabled, setValue]);
+
+  useEffect(() => {
+    if (!map) {
+      return;
+    }
+    const onIdle = (e: { target: MaplibreMap }) => {
+      load('state.json')
+        .then((store) => {
+          const newInitialLoc: Loc = {
+            ...e.target.getCenter(),
+            zoom: e.target.getZoom(),
+          };
+          return store.set(INITIAL_LOC_KEY, newInitialLoc);
+        })
+        .catch((err) => {
+          console.error('Failed to save new initial map location:', err);
+        });
+    };
+    map.on('idle', onIdle);
+    return () => {
+      map.off('idle', onIdle);
+    };
+  }, [map]);
+
+  useTauriListener(FOCUS_ON_LOCATION_EVENT, () => {
+    if (!map) {
+      return;
+    }
     const [lat, lon] = getValues(['GPSLatitude', 'GPSLongitude']);
-    if (lat && lon) {
-      mapRef.current.setCenter([lon, lat]);
+    if (typeof lat === 'number' && typeof lon === 'number') {
+      map.setCenter([lon, lat]);
     }
   });
 
-  const onMapIdle = useCallback((e: MapLibreEvent) => {
-    load('state.json')
-      .then((store) => {
-        const newInitialLoc: Loc = {
-          ...e.target.getCenter(),
-          zoom: e.target.getZoom(),
-        };
-        return store.set('initialLoc', newInitialLoc);
-      })
-      .catch((err) => {
-        console.error('Failed to save new initial map location:', err);
-      });
-  }, []);
+  return (
+    <>
+      <div ref={containerRef} className="h-full w-full" />
+      {map && <LocationPin map={map} />}
+    </>
+  );
+}
 
-  if (!initialLoc) {
-    return <div className="skeleton h-full w-full" title="Loading Map"></div>;
+function LocationMap() {
+  const { data, isLoading } = useSWR(SWR_KEY, loadInitialLoc, {
+    revalidateOnFocus: false,
+  });
+
+  if (isLoading || !data) {
+    return (
+      <Skeleton aria-label="Loading Map" className="h-full w-full rounded-md" />
+    );
   }
 
-  return (
-    <MapGL
-      ref={mapRef}
-      reuseMaps
-      initialViewState={{
-        latitude: initialLoc.lat,
-        longitude: initialLoc.lng,
-        zoom: initialLoc.zoom,
-      }}
-      mapStyle="https://tiles.openfreemap.org/styles/bright"
-      onClick={({ lngLat: { lat, lng } }) => {
-        if (!disabled) {
-          setValue('GPSLatitude', lat, {
-            shouldDirty: true,
-            shouldValidate: true,
-          });
-          setValue('GPSLongitude', lng, {
-            shouldDirty: true,
-            shouldValidate: true,
-          });
-        }
-      }}
-      onIdle={onMapIdle}
-    >
-      <LocationPin />
-    </MapGL>
-  );
+  return <MapView initialLoc={data} />;
 }
 
 export default LocationMap;

--- a/src/screens/Shell/MetadataEditorPanel/LocationMap.tsx
+++ b/src/screens/Shell/MetadataEditorPanel/LocationMap.tsx
@@ -37,6 +37,19 @@ async function loadInitialLoc(): Promise<Loc> {
   }
 }
 
+async function onIdle(e: { target: MaplibreMap }) {
+  try {
+    const store = await load('state.json');
+    const newInitialLoc: Loc = {
+      ...e.target.getCenter(),
+      zoom: e.target.getZoom(),
+    };
+    return store.set(INITIAL_LOC_KEY, newInitialLoc);
+  } catch (err) {
+    reportError('Failed to save initial map location', err, true);
+  }
+}
+
 function LocationPin({ map }: { map: MaplibreMap }) {
   const { watch, getFieldState } = useFormContext<ExifData>();
   const lat = watch('GPSLatitude');
@@ -134,19 +147,6 @@ function MapView({ initialLoc }: { initialLoc: Loc }) {
     if (!map) {
       return;
     }
-    const onIdle = (e: { target: MaplibreMap }) => {
-      load('state.json')
-        .then((store) => {
-          const newInitialLoc: Loc = {
-            ...e.target.getCenter(),
-            zoom: e.target.getZoom(),
-          };
-          return store.set(INITIAL_LOC_KEY, newInitialLoc);
-        })
-        .catch((err) => {
-          reportError('Failed to save initial map location', err, true);
-        });
-    };
     map.on('idle', onIdle);
     return () => {
       map.off('idle', onIdle);

--- a/src/screens/Shell/MetadataEditorPanel/LocationMap.tsx
+++ b/src/screens/Shell/MetadataEditorPanel/LocationMap.tsx
@@ -1,6 +1,7 @@
 import { Skeleton } from '@heroui/react';
 import useTauriListener from '@hooks/useTauriListener';
 import type { ExifData } from '@metadata-handler/exifdata';
+import { reportError } from '@platform/error-reporter';
 import { FOCUS_ON_LOCATION_EVENT } from '@platform/menus/tools-menu';
 import { load } from '@tauri-apps/plugin-store';
 import maplibregl, { type Map as MaplibreMap } from 'maplibre-gl';
@@ -31,7 +32,7 @@ async function loadInitialLoc(): Promise<Loc> {
     const parsed = await Loc.safeParseAsync(raw);
     return parsed.success ? parsed.data : DEFAULT_LOC;
   } catch (err) {
-    console.error('Failed to load map state:', err);
+    reportError('Failed to load map state', err, true);
     return DEFAULT_LOC;
   }
 }
@@ -143,7 +144,7 @@ function MapView({ initialLoc }: { initialLoc: Loc }) {
           return store.set(INITIAL_LOC_KEY, newInitialLoc);
         })
         .catch((err) => {
-          console.error('Failed to save new initial map location:', err);
+          reportError('Failed to save initial map location', err, true);
         });
     };
     map.on('idle', onIdle);

--- a/src/screens/Shell/MetadataEditorPanel/__specs__/LocationMap.spec.tsx
+++ b/src/screens/Shell/MetadataEditorPanel/__specs__/LocationMap.spec.tsx
@@ -1,0 +1,376 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { defaultExifData, ExifData } from '@metadata-handler/exifdata';
+import { mockIPC } from '@tauri-apps/api/mocks';
+import { load } from '@tauri-apps/plugin-store';
+import { render, screen, waitFor } from '@testing-library/react';
+import maplibregl from 'maplibre-gl';
+import { act, type ReactNode } from 'react';
+import { FormProvider, useForm, useFormContext } from 'react-hook-form';
+import { SWRConfig } from 'swr';
+import type { Mock } from 'vitest';
+import LocationMap from '../LocationMap';
+
+vi.mock('@tauri-apps/api/menu');
+vi.mock('@tauri-apps/plugin-store');
+vi.mock('maplibre-gl', () => {
+  const MapCtor = vi.fn(function (this: unknown, options: unknown) {
+    Object.assign(this as object, {
+      options,
+      on: vi.fn().mockReturnThis(),
+      off: vi.fn(),
+      setCenter: vi.fn(),
+      getCenter: vi.fn(),
+      getZoom: vi.fn(),
+      remove: vi.fn(),
+    });
+  });
+  const MarkerCtor = vi.fn(function (this: unknown, options: unknown = {}) {
+    Object.assign(this as object, {
+      options,
+      setLngLat: vi.fn().mockReturnThis(),
+      addTo: vi.fn().mockReturnThis(),
+      remove: vi.fn().mockReturnThis(),
+    });
+  });
+  return {
+    default: { Map: MapCtor, Marker: MarkerCtor },
+    Map: MapCtor,
+    Marker: MarkerCtor,
+  };
+});
+
+interface MockedMap {
+  options: {
+    container: HTMLElement;
+    style: string;
+    center: [number, number];
+    zoom: number;
+  };
+  on: Mock;
+  off: Mock;
+  setCenter: Mock;
+  getCenter: Mock;
+  getZoom: Mock;
+  remove: Mock;
+}
+
+function getMap() {
+  return vi.mocked(maplibregl.Map).mock.instances[0] as unknown as MockedMap;
+}
+
+function getMarker() {
+  return vi.mocked(maplibregl.Marker).mock.instances[0];
+}
+
+function getHandler(
+  map: MockedMap,
+  event: string,
+): ((payload: unknown) => void) | undefined {
+  const call = map.on.mock.calls.find(([e]) => e === event);
+  // biome-ignore lint/style/noNonNullAssertion: tests should fail loudly
+  return call![1];
+}
+
+interface FormHandle {
+  setValue: ReturnType<typeof useForm>['setValue'];
+  reset: ReturnType<typeof useForm>['reset'];
+}
+
+const formHandleRef: { current: FormHandle | null } = { current: null };
+
+function TestContainer({
+  disabled = false,
+  children,
+}: {
+  disabled?: boolean;
+  children?: ReactNode;
+}) {
+  const form = useForm({
+    resolver: zodResolver(ExifData),
+    defaultValues: defaultExifData,
+    disabled,
+  });
+  formHandleRef.current = { setValue: form.setValue, reset: form.reset };
+
+  return (
+    <SWRConfig value={{ provider: () => new Map() }}>
+      <FormProvider {...form}>
+        <LocationMap />
+        {children}
+      </FormProvider>
+    </SWRConfig>
+  );
+}
+
+function makeStore(initial?: Record<string, unknown>) {
+  const data = new Map<string, unknown>(Object.entries(initial ?? {}));
+  return data as unknown as Awaited<ReturnType<typeof load>>;
+}
+
+async function waitForMapWired() {
+  await waitFor(() => {
+    const map = getMap();
+    expect(map).toBeTruthy();
+    expect(map.on).toHaveBeenCalledWith('click', expect.any(Function));
+    expect(map.on).toHaveBeenCalledWith('idle', expect.any(Function));
+    expect(getMarker()).toBeTruthy();
+  });
+}
+
+describe('LocationMap', () => {
+  beforeEach(() => {
+    mockIPC(() => {}, { shouldMockEvents: true });
+    formHandleRef.current = null;
+  });
+
+  it('renders the loading skeleton while the initial location is loading', () => {
+    vi.mocked(load).mockReturnValueOnce(new Promise(() => {}));
+    render(<TestContainer />);
+    expect(screen.getByLabelText('Loading Map')).toBeVisible();
+    expect(getMap()).toBeUndefined();
+  });
+
+  it('falls back to the default location when state.json has no initialLoc', async () => {
+    vi.mocked(load).mockResolvedValueOnce(makeStore());
+    render(<TestContainer />);
+    await waitForMapWired();
+    expect(getMap().options.center).toEqual([0, 0]);
+    expect(getMap().options.zoom).toBe(0);
+  });
+
+  it('initially centers and zooms to the last saved location', async () => {
+    vi.mocked(load).mockResolvedValueOnce(
+      makeStore({ initialLoc: { lat: 51.5, lng: -0.12, zoom: 10 } }),
+    );
+    render(<TestContainer />);
+    await waitForMapWired();
+    expect(getMap().options.center).toEqual([-0.12, 51.5]);
+    expect(getMap().options.zoom).toBe(10);
+  });
+
+  describe('marker placement', () => {
+    beforeEach(() => {
+      vi.mocked(load).mockResolvedValueOnce(makeStore());
+    });
+
+    async function renderAndWaitForMap() {
+      render(<TestContainer />);
+      await waitForMapWired();
+    }
+
+    it('places the pin at the form value when both coords are set', async () => {
+      await renderAndWaitForMap();
+      await act(async () => {
+        formHandleRef.current?.setValue('GPSLatitude', 40);
+        formHandleRef.current?.setValue('GPSLongitude', -74);
+      });
+      await waitFor(() => {
+        expect(getMarker().setLngLat).toHaveBeenCalledWith([-74, 40]);
+        expect(getMarker().addTo).toHaveBeenCalled();
+      });
+    });
+
+    it('updates the pin when the lat/lng change', async () => {
+      await renderAndWaitForMap();
+      await act(async () => {
+        formHandleRef.current?.setValue('GPSLatitude', 40);
+        formHandleRef.current?.setValue('GPSLongitude', -74);
+      });
+      await waitFor(() =>
+        expect(getMarker().setLngLat).toHaveBeenLastCalledWith([-74, 40]),
+      );
+
+      await act(async () => {
+        formHandleRef.current?.setValue('GPSLatitude', 41);
+      });
+      await waitFor(() =>
+        expect(getMarker().setLngLat).toHaveBeenLastCalledWith([-74, 41]),
+      );
+    });
+
+    it('does not place the pin when a non-number is entered', async () => {
+      await renderAndWaitForMap();
+      await act(async () => {
+        formHandleRef.current?.setValue(
+          'GPSLatitude',
+          'some garbage' as unknown as number,
+          { shouldValidate: true },
+        );
+        formHandleRef.current?.setValue('GPSLongitude', -74, {
+          shouldValidate: true,
+        });
+      });
+      expect(getMarker()).toBeTruthy();
+      expect(getMarker().addTo).not.toHaveBeenCalled();
+    });
+
+    it('does not place the pin when neither coord is set', async () => {
+      await renderAndWaitForMap();
+      expect(getMarker()).toBeTruthy();
+      expect(getMarker().addTo).not.toHaveBeenCalled();
+    });
+
+    it('does not place the pin when only one coord is set', async () => {
+      await renderAndWaitForMap();
+      await act(async () => {
+        formHandleRef.current?.setValue('GPSLatitude', 40);
+      });
+      expect(getMarker()).toBeTruthy();
+      expect(getMarker().addTo).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the map is clicked', () => {
+    beforeEach(() => {
+      vi.mocked(load).mockResolvedValueOnce(makeStore());
+    });
+
+    async function renderAndFireClick(lngLat: { lat: number; lng: number }) {
+      render(<TestContainer />);
+      await waitForMapWired();
+      const map = getMap();
+      const click = getHandler(map, 'click');
+      await act(async () => {
+        click?.({ lngLat });
+      });
+      return map;
+    }
+
+    it('updates the location inputs', async () => {
+      function ValueProbe() {
+        const { watch } = useFormContext<ExifData>();
+        const lat = watch('GPSLatitude');
+        const lon = watch('GPSLongitude');
+        return (
+          <>
+            <span data-testid="lat">{String(lat)}</span>
+            <span data-testid="lon">{String(lon)}</span>
+          </>
+        );
+      }
+
+      render(
+        <TestContainer>
+          <ValueProbe />
+        </TestContainer>,
+      );
+      await waitForMapWired();
+
+      const click = getHandler(getMap(), 'click');
+      await act(async () => {
+        click?.({ lngLat: { lat: 12.34, lng: 56.78 } });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('lat').textContent).toBe('12.34');
+        expect(screen.getByTestId('lon').textContent).toBe('56.78');
+      });
+    });
+
+    it('dirties the form and triggers validation', async () => {
+      function StateProbe() {
+        const {
+          formState: { isDirty, isValid },
+        } = useFormContext<ExifData>();
+        return (
+          <>
+            <span data-testid="dirty">{String(isDirty)}</span>
+            <span data-testid="valid">{String(isValid)}</span>
+          </>
+        );
+      }
+
+      render(
+        <TestContainer>
+          <StateProbe />
+        </TestContainer>,
+      );
+      await waitForMapWired();
+      expect(screen.getByTestId('dirty').textContent).toBe('false');
+
+      const click = getHandler(getMap(), 'click');
+      await act(async () => {
+        click?.({ lngLat: { lat: 12.34, lng: 56.78 } });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('dirty').textContent).toBe('true');
+        expect(screen.getByTestId('valid').textContent).toBe('true');
+      });
+    });
+
+    it('moves the pin to the clicked location', async () => {
+      await renderAndFireClick({ lat: 9, lng: 8 });
+      await waitFor(() => {
+        expect(getMarker().setLngLat).toHaveBeenLastCalledWith([8, 9]);
+        expect(getMarker().addTo).toHaveBeenCalled();
+      });
+    });
+
+    describe('when the form is disabled', () => {
+      it('does nothing on click', async () => {
+        render(<TestContainer disabled />);
+        await waitForMapWired();
+
+        const click = getHandler(getMap(), 'click');
+        await act(async () => {
+          click?.({ lngLat: { lat: 9, lng: 8 } });
+        });
+
+        expect(getMarker()).toBeTruthy();
+        expect(getMarker().addTo).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when the map idles', () => {
+    it('persists the centered location and zoom to the app state', async () => {
+      const store = makeStore({
+        initialLoc: { lat: 51.5, lng: -0.12, zoom: 10 },
+      });
+      vi.mocked(load).mockResolvedValue(store);
+
+      render(<TestContainer />);
+      await waitForMapWired();
+      const map = getMap();
+
+      map.getCenter.mockReturnValueOnce({ lat: 1, lng: 2 });
+      map.getZoom.mockReturnValueOnce(5);
+
+      const idle = getHandler(map, 'idle');
+      await act(async () => {
+        idle?.({ target: map });
+      });
+
+      await waitFor(() => {
+        expect(store.get('initialLoc')).toEqual({
+          lat: 1,
+          lng: 2,
+          zoom: 5,
+        });
+      });
+    });
+
+    it('does not throw when the save fails', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      let callCount = 0;
+      vi.mocked(load).mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return makeStore();
+        }
+        throw new Error('disk full');
+      });
+
+      render(<TestContainer />);
+      await waitForMapWired();
+      const map = getMap();
+      const idle = getHandler(map, 'idle');
+
+      expect(() => idle?.({ target: map })).not.toThrow();
+
+      await waitFor(() => expect(errorSpy).toHaveBeenCalled());
+      errorSpy.mockRestore();
+    });
+  });
+});

--- a/src/screens/Shell/MetadataEditorPanel/__specs__/LocationTab.spec.tsx
+++ b/src/screens/Shell/MetadataEditorPanel/__specs__/LocationTab.spec.tsx
@@ -1,19 +1,14 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ExifData } from '@metadata-handler/exifdata';
 import { mockIPC } from '@tauri-apps/api/mocks';
-import { load } from '@tauri-apps/plugin-store';
 import { render, screen } from '@testing-library/react';
 import { FormProvider, useForm } from 'react-hook-form';
-import type { Mock } from 'vitest';
 import LocationTab from '../LocationTab';
 
 vi.mock('@tauri-apps/api/menu');
-vi.mock('@tauri-apps/plugin-store', () => ({
-  load: vi.fn<typeof load>(() => new Promise(() => {})),
+vi.mock('../LocationMap', () => ({
+  default: () => null,
 }));
-const loadMock = load as unknown as Mock<typeof load>;
-
-vi.mock('react-map-gl/maplibre');
 
 function TestContainer() {
   const form = useForm({
@@ -36,56 +31,5 @@ describe('LocationTab', () => {
     render(<TestContainer />);
     expect(screen.getByLabelText('GPSLatitude')).toBeVisible();
     expect(screen.getByLabelText('GPSLongitude')).toBeVisible();
-  });
-
-  it('indicates that the map is loading', async () => {
-    render(<TestContainer />);
-    expect(screen.getByTitle('Loading Map')).toBeVisible();
-    expect(screen.queryByText('MapGL Output')).toBeNull();
-  });
-
-  describe('when the previous map state has loaded', () => {
-    it('initially centers the map to London by default', async () => {
-      loadMock.mockResolvedValueOnce(
-        new Map() as unknown as Awaited<ReturnType<typeof load>>,
-      );
-      render(<TestContainer />);
-      expect(screen.queryByText('Loading Map')).toBeNull();
-      expect(await screen.findByText('MapGL Output')).toBeVisible();
-    });
-
-    it.todo('sets a pin to the form value');
-
-    it.todo('updates the pin when the text input is updated');
-
-    it.todo('does not break the map when a non-number is entered');
-
-    it.todo('has no pin when there is no value for location');
-
-    it.todo('handles one of the location fields is not set');
-
-    describe('when the map is clicked', () => {
-      it.todo('updates the location inputs');
-
-      it.todo('dirties the form and triggers validation');
-
-      it.todo('moves the pin');
-
-      describe('when the form is disabled', () => {
-        it.todo('does nothing');
-      });
-    });
-
-    describe('when the map is moved', () => {
-      it.todo('persists the centered location and zoom to the app state');
-
-      it.todo('does not matter if the save fails');
-    });
-
-    describe('when the map has been moved', () => {
-      it.todo(
-        'initially centers the map and zoom to where it was last moved to',
-      );
-    });
   });
 });

--- a/src/screens/Shell/MetadataEditorPanel/__specs__/MetadataEditorPanel.spec.tsx
+++ b/src/screens/Shell/MetadataEditorPanel/__specs__/MetadataEditorPanel.spec.tsx
@@ -36,7 +36,9 @@ vi.mock(import('@heroui/react'), async (importOriginal) => {
   return original;
 });
 
-vi.mock('react-map-gl/maplibre');
+vi.mock('../LocationMap', () => ({
+  default: () => null,
+}));
 vi.mock('@tauri-apps/api/menu');
 
 const Wrapper = ({ children }: { children: ReactNode }) => (


### PR DESCRIPTION
Switched from using `react-map-gl` to using `maplibre-gl` and manually handling getting it working well in react. Largely to make it easier to backfill tests, but also because the react components from the library were kinda brittle and this use didn't *really* benefit from it.